### PR TITLE
docs: clarify Python 3.12 support

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -581,10 +581,13 @@ Everyone reviews everyone's PRs. No direct pushes to `main`.
 
 ### 13.1 System requirements
 
-- **OS:** Windows 10/11, macOS, or Linux.
-- **RAM:** 16 GB recommended (8 GB minimum, use `phi3:mini` instead).
-- **Disk:** 10 GB free (the models are ~5 GB).
-- **Python:** 3.10 or 3.11.
+* **OS:** Windows 10/11, macOS, or Linux.
+* **RAM:** 16 GB recommended (8 GB minimum, use `phi3:mini` instead).
+* **Disk:** 10 GB free (the models are ~5 GB).
+* **Python:** 3.10, 3.11, or 3.12.
+
+> **Note:** Python 3.12 has been tested successfully with this project. Ubuntu 24.04 LTS users can use the default Python 3.12 installation without requiring an older Python version.
+
 
 ### 13.2 Install Ollama
 


### PR DESCRIPTION
## What

Add Python 3.12 to the supported Python versions in GUIDE.md and document Python 3.12 compatibility for Ubuntu 24.04 LTS users.

## Why

The project has been tested successfully with Python 3.12. Ubuntu 24.04 LTS ships with Python 3.12 by default, so documenting this compatibility helps users avoid unnecessary Python version changes during setup.

## How

* Updated the system requirements to include Python 3.12.
* Added a note clarifying Python 3.12 support and Ubuntu 24.04 LTS compatibility.

## Testing

* Verified project setup and execution using Python 3.12 on Ubuntu 24.04 LTS.
* Successfully installed dependencies, built the knowledge base, and ran the application locally.
