### PR TITLE
docs: fix minor typo in GUIDE.md heading

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -1,4 +1,4 @@
-# Telemed Chatbot —  Guide
+# Telemed Chatbot — Guide
 
 > A 3-month open-source MVP for ML beginners.
 > A symptom-triage chatbot built with **GraphRAG** — combining a **knowledge graph** of medical concepts with **vector search** — grounded on the **MedlinePlus** corpus.


### PR DESCRIPTION
Closes #1\n\nFixes a minor typo: double space after em-dash in the GUIDE.md title heading.