### PR TITLE
docs: remove python 3.12 for docs consistency

### DIFF
--- a/phase/PHASE_0.md
+++ b/phase/PHASE_0.md
@@ -122,7 +122,7 @@ Most distros ship Python. Verify the version is 3.10+:
 python3 --version
 ```
 
-Any version starting with `3.10`, `3.11`, or `3.12` is acceptable. `3.8` and `3.9` are too old; upgrade.
+Any version starting with `3.10`, or `3.11` is acceptable. `3.8` and `3.9` are too old; upgrade.
 
 ### 5.2 Git
 


### PR DESCRIPTION
## What

Changed line 125 in PHASE_0.md to Any version starting with `3.10`, or `3.11` is acceptable. `3.8` and `3.9` are too old; upgrade.

Previously was: Any version starting with `3.10`, `3.11`, or `3.12` is acceptable. `3.8` and `3.9` are too old; upgrade.

## Why

All other docs mention version 3.10 or 3.11 explicitly, never 3.12.  For consistency reasons, either completely remove 3.12 as it is mentioned once, or mention it everywhere else where it wasn't mentioned.

## How

I've removed "3.12" from the text string

## Testing

Had no issues with the preview syntax following the change.