### PR TITLE
feat: handle empty results with fallback message (#2)

### DIFF
--- a/backend/app/ingestion/data_loader.py
+++ b/backend/app/ingestion/data_loader.py
@@ -209,6 +209,7 @@ def build_clean_jsonl() -> Path:
     print(f"Parsing {xml_path.name} ...")
 
     count = 0
+    skipped = 0
     # `with open(...)` ensures the file is closed automatically when we're done,
     # even if an error happens mid-loop.
     with CLEAN_JSONL.open("w", encoding="utf-8") as f:
@@ -218,10 +219,15 @@ def build_clean_jsonl() -> Path:
         for rec in tqdm(iter_topics(xml_path), unit="topics"):
             # json.dumps turns the Python dict into a JSON string.
             # We append "\n" so each record sits on its own line.
+            if not rec.get("text"):
+                skipped += 1
+                continue
             f.write(json.dumps(rec, ensure_ascii=False) + "\n")
             count += 1
 
     print(f"Wrote {count} topics to {CLEAN_JSONL}")
+    if skipped:
+        print(f"  (skipped {skipped} topics with empty text)")
     return CLEAN_JSONL
 
 

--- a/backend/app/services/graph_rag.py
+++ b/backend/app/services/graph_rag.py
@@ -49,6 +49,16 @@ def answer(question: str) -> RagResult:
     retriever = get_retriever()
     result = retriever.retrieve(question)
 
+    # Fallback: if no relevant documents found, return early instead of
+    # asking the LLM to guess from an empty context.
+    if not result.docs:
+        return {
+            "answer": "No official MedlinePlus documentation found for this entity.",
+            "sources": [],
+            "entities": result.matched_entities,
+            "candidate_conditions": result.candidate_conditions,
+        }
+
     prompt = get_triage_prompt()
     llm = get_llm(temperature=0.2)
     chain = prompt | llm | StrOutputParser()

--- a/backend/scripts/ingest.py
+++ b/backend/scripts/ingest.py
@@ -29,6 +29,10 @@ def main() -> None:
     print("Step 1/4: loading clean MedlinePlus records ...")
     records = load_records()
     print(f"  loaded {len(records)} topics")
+    if not records:
+        print("  ⚠  No records found — the MedlinePlus XML may be empty or missing.")
+        print("  Fallback will be used at query time.")
+        return
 
     print("Step 2/4: chunking ...")
     docs = records_to_documents(records)


### PR DESCRIPTION
When a user searches for something MedlinePlus has no article on, the API now returns a proper fallback instead of letting the LLM guess from empty context.

- quick check in  — returns the fallback string when the retriever returns zero docs
-  warns if records come back empty
-  counts skipped empty-topic records

Closes #2