### PR TITLE
fix: resolve broken table of contents link for section 16

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -23,7 +23,7 @@
 13. [Environment setup](#13-environment-setup)
 14. [How to read this codebase](#14-how-to-read-this-codebase)
 15. [Evaluation](#15-evaluation)
-16. [Safety, ethics, disclaimers](#16-safety-ethics-disclaimers)
+16. [Safety & quality guardrails](#16-safety--quality-guardrails)
 17. [Git workflow](#17-git-workflow)
 18. [Common pitfalls](#18-common-pitfalls)
 19. [Stretch goals](#19-stretch-goals)


### PR DESCRIPTION
Fixes a broken anchor link in the Table of Contents for Section 16 so it correctly routes to the Safety & quality guardrails heading.