### PR TITLE
docs: fix invalid --step flag in ingest DoD command #430

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -427,7 +427,7 @@ flowchart LR
 
 **Deliverable:** Clean JSONL + EDA notebook.
 
-**DoD:** Running `python backend/scripts/ingest.py --step data` produces a non-empty JSONL.
+**DoD:** Running `python -m backend.scripts.ingest --limit 50` produces a non-empty JSONL.
 
 ---
 


### PR DESCRIPTION
What
Fixes the Phase 1 "Definition of Done" command in GUIDE.md line 430 it referenced a `--step` flag that doesn't exist on `backend/scripts/ingest.py`.

Why
`backend/scripts/ingest.py` only defines `--limit`, `--skip-graph`, and `--skip-vectors` via argparse. Following the documented command (`python backend/scripts/ingest.py --step data`) as written fails immediately with `unrecognized arguments: --step data`. It also invokes the script as a file path rather than a module, which breaks the script's absolute imports (`from backend.app...`). Every other place in the docs (README.md, GUIDE.md §13.5, and the script's own docstring) correctly uses `python -m backend.scripts.ingest`.

How
Changed the DoD line in GUIDE.md to `python -m backend.scripts.ingest --limit 50`, matching the script's actual supported flags and the "quick smoke test" usage documented in the script's own docstring.

Testing
N/A — docs only. Verified by reading `backend/scripts/ingest.py`'s argparse definition; `--step` is not a recognized argument anywhere in the codebase.

