### PR TITLE
docs: fix typos in documentation in GUIDE.MD Line 220

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -217,7 +217,7 @@ flowchart TB
     EMB --> L2
 ```
 
-Two independent processes:
+Three independent processes:
 1. **Backend** runs on `http://localhost:8000` (FastAPI / Uvicorn).
 2. **Frontend** runs on `http://localhost:8501` (Streamlit).
 3. **Ollama** runs on `http://localhost:11434` and is shared.


### PR DESCRIPTION
## What
Fix a typo in `GUIDE.md` Section 7 (System architecture) regarding the number of independent processes.
## Why
The text previously stated there were "two" independent processes, but the list immediately following it clearly outlines three distinct processes (Backend, Frontend, and Ollama). This change corrects the text to accurately reflect the architecture and prevent confusing beginners reading the guide.
## How
Changed the word "Two" to "Three" on line 220.
## Testing
N/A — Documentation only.

Addresses #1 