### PR TITLE
Docs/update readme.md

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -217,7 +217,7 @@ flowchart TB
     EMB --> L2
 ```
 
-Two independent processes:
+Three independent processes:
 1. **Backend** runs on `http://localhost:8000` (FastAPI / Uvicorn).
 2. **Frontend** runs on `http://localhost:8501` (Streamlit).
 3. **Ollama** runs on `http://localhost:11434` and is shared.

--- a/README.md
+++ b/README.md
@@ -9,32 +9,44 @@ Describe symptoms → hybrid retrieval (knowledge graph + vector search) → loc
 
 ## Quickstart
 
+### 1. Model & Data Setup
+
+Install [Ollama](https://ollama.com/) and pull the necessary local models:
+
 ```bash
-# 1. Install Ollama (https://ollama.com/) and pull models
 ollama pull llama3.1:8b
 ollama pull nomic-embed-text
+```
 
-# 2. Download MedlinePlus XML (https://medlineplus.gov/xml.html)
-#    Place it in data/raw/
+Download the [MedlinePlus XML dataset](https://medlineplus.gov/xml.html) and place it in the `data/raw/` directory.
 
-# 3. Backend
+### 2. Backend Initialization (FastAPI)
+
+```bash
 cd backend
 python -m venv .venv && source .venv/bin/activate   # Windows: .venv\Scripts\activate
 pip install -r requirements.txt
 cp .env.example .env
 
-# 4. Build the knowledge base (one-time, takes a while)
+# Build the knowledge base (one-time, takes a while)
 cd ..
 python -m backend.scripts.ingest
 
-# 5. Start the backend
+# Start the backend API
 uvicorn backend.app.main:app --reload --port 8000
+```
 
-# 6. In a NEW terminal — frontend
+### 3. Frontend Initialization (Streamlit)
+
+Open a **NEW terminal window**:
+
+```bash
 cd frontend
-python -m venv .venv && source .venv/bin/activate
+python -m venv .venv && source .venv/bin/activate   # Windows: .venv\Scripts\activate
 pip install -r requirements.txt
 cp .env.example .env
+
+# Start the interface
 streamlit run app.py
 ```
 


### PR DESCRIPTION
## What
Format the `README.md` Quickstart section by breaking the single monolithic bash block into three distinct steps with markdown headings.

## Why
Beginners often copy and paste entire code blocks at once. Because the previous setup had the backend and frontend initialization commands sitting in the exact same code block, running it all at once would trap them in the blocking backend server, preventing the frontend commands from ever executing.

## How
Separated the bash commands into `1. Model & Data Setup`, `2. Backend Initialization`, and `3. Frontend Initialization`. Added brief prose instructions between them to explicitly tell the user when to open a new terminal window.

## Testing
N/A — Markdown documentation formatting only.
